### PR TITLE
Add fields to search via Tags as well as select an exact build by its build number

### DIFF
--- a/fetch-build-artifact-task/index.ts
+++ b/fetch-build-artifact-task/index.ts
@@ -37,6 +37,8 @@ async function run() {
             throw new Error('Build Definition Id must be a numerical value');
         }
 
+        let buildNumber = task.getInput('buildNumber', false);
+
         let artifactName = task.getInput('artifactName', true);
 
         // Validate targetDirectory
@@ -51,6 +53,8 @@ async function run() {
         let buildsUri = projectUri + '/_apis/build/builds';
         task.debug('buildsUri=' + buildsUri);
 
+        let tagsToSearchFor = task.getInput('tagsToSearchFor', false);
+
         var buildsOptions = getRequestOptions({
             uri: buildsUri,
             qs: {
@@ -60,6 +64,21 @@ async function run() {
                 $top: 1
             }
         });
+
+		// If we specified a particular build to use, add that to the search option.
+        if(buildNumber)
+        {
+            buildsOptions.qs = Object.assign(buildsOptions.qs, { 'buildNumber': buildNumber });
+        }
+        else
+        {
+			// If we did not specify a particular build to use, then we can add the tag filter if specified.
+            if(tagsToSearchFor)
+            {
+                buildsOptions.qs = Object.assign(buildsOptions.qs, { 'tagFilters': tagsToSearchFor });
+            }
+        }
+        
         task.debug('buildsOptions=' + JSON.stringify(buildsOptions));
 
         console.log('Requesting build artifact \'' + artifactName + '\'...')

--- a/fetch-build-artifact-task/package.json
+++ b/fetch-build-artifact-task/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/adm-zip": "^0.4.31",
     "@types/mocha": "^2.2.40",
-    "@types/request": "0.0.41",
+    "@types/request": "^0.0.45",
     "@types/request-promise-native": "^1.0.2",
     "assert": "^1.4.1",
     "mocha": "^3.2.0"

--- a/fetch-build-artifact-task/task.json
+++ b/fetch-build-artifact-task/task.json
@@ -1,80 +1,109 @@
 {
-    "id": "eac0431e-6ffc-4dc6-be6e-d296e9686ca6",
-    "name": "fetch-build-artifact",
-    "friendlyName": "Fetch Build Artifacts",
-    "description": "Fetch build artifacts from the server or a file share",
-    "helpMarkDown": "Requires **Allow Scripts to Access OAuth Token** to be **enabled**.<br/><br>Having Problems? Please [create an issue on our Github](https://github.com/BoolBySigma/FetchBuildArtifact/issues) and we will try to help you.",
-    "category": "Utility",
-    "author": "Bool (by Sigma)",
-    "version": {
-        "Major": 0,
-        "Minor": 0,
-        "Patch": 1
+  "id": "eac0431e-6ffc-4dc6-be6e-d296e9686ca6",
+  "name": "fetch-build-artifact",
+  "friendlyName": "Fetch Build Artifacts",
+  "description": "Fetch build artifacts from the server or a file share",
+  "helpMarkDown": "Requires **Allow Scripts to Access OAuth Token** to be **enabled**.<br/><br>Having Problems? Please [create an issue on our Github](https://github.com/BoolBySigma/FetchBuildArtifact/issues) and we will try to help you.",
+  "category": "Utility",
+  "author": "Bool (by Sigma)",
+  "version": {
+    "Major": 0,
+    "Minor": 0,
+    "Patch": 1
+  },
+  "instanceNameFormat": "Fetch Artifact: $(artifactName)",
+  "inputs": [
+    {
+      "name": "project",
+      "type": "pickList",
+      "label": "Project",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Project from where to fetch the build artifact.",
+      "properties": {
+        "DisableManageLink": "True"
+      }
     },
-    "instanceNameFormat": "Fetch Artifact: $(artifactName)",
-    "inputs": [
-        {
-            "name": "project",
-            "type": "pickList",
-            "label": "Project",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Project from where to fetch the build artifact.",
-            "properties": {
-                "DisableManageLink": "True"
-            }
-        },
-        {
-            "name": "buildDefinitionId",
-            "type": "pickList",
-            "label": "Build Definition",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Build definition from where to fetch build artifact.",
-            "properties": {
-                "DisableManageLink": "True"
-            },
-            "visibleRule": "project != \"\""
-        },
-        {
-            "name": "artifactName",
-            "type": "string",
-            "label": "Build Artifact Name",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Name of the artifact to fetch, eg. 'drop'.",
-            "visibleRule": "buildDefinitionId != \"\""
-        },
-        {
-            "name": "targetDirectory",
-            "type": "filePath",
-            "label": "Target Folder",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "The directory where to download the artifact. Leaving it blank defaults to source root directory and is equal to using <code>$(Build.SourcesDirectory)</code>.",
-            "visibleRule": "buildDefinitionId != \"\""
-        }
-    ],
-    "sourceDefinitions": [
-        {
-            "target": "project",
-            "endpoint": "/_api/_wit/teamProjects?__v=5",
-            "selector": "jsonpath:$.projects[*].name",
-            "keySelector": "jsonpath:$.projects[*].guid",
-            "authKey": "tfs:teamfoundation"
-        },
-        {
-            "target": "buildDefinitionId",
-            "endpoint": "/$(project)/_apis/build/Definitions?queryOrder=3",
-            "selector": "jsonpath:$.value[*].name",
-            "keySelector": "jsonpath:$.value[*].id",
-            "authKey": "tfs:teamfoundation"
-        }
-    ],
-    "execution": {
-        "Node": {
-            "target": "index.js",
-            "argumentFormat": ""
-        }
+    {
+      "name": "buildDefinitionId",
+      "type": "pickList",
+      "label": "Build Definition",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Build definition from where to fetch build artifact.",
+      "properties": {
+        "DisableManageLink": "True"
+      },
+      "visibleRule": "project != \"\""
+    },
+    {
+      "name": "buildNumber",
+      "type": "pickList",
+      "label": "Build Number",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Choose a specific build to retrieve the artifacts from. Leave blank to get the latest. Setting this will override choices made in the Tags field.",
+      "properties": {
+        "EditableOptions": "True",
+        "DisableManageLink": "True"
+      },
+      "visibleRule": "buildDefinitionId != \"\""
+    },
+    {
+      "name": "artifactName",
+      "type": "string",
+      "label": "Build Artifact Name",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Name of the artifact to fetch, eg. 'drop'.",
+      "visibleRule": "buildDefinitionId != \"\""
+    },
+    {
+      "name": "tagsToSearchFor",
+      "type": "string",
+      "label": "Tags",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Define a comma separated list of tags the build to retrieve needs to have.  Tags will be ignored if a specific build is specified.",
+      "visibleRule": "buildDefinitionId != \"\""
+    },
+    {
+      "name": "targetDirectory",
+      "type": "filePath",
+      "label": "Target Folder",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "The directory where to download the artifact. Leaving it blank defaults to source root directory and is equal to using <code>$(Build.SourcesDirectory)</code>.",
+      "visibleRule": "buildDefinitionId != \"\""
     }
+  ],
+  "sourceDefinitions": [
+    {
+      "target": "project",
+      "endpoint": "/_api/_wit/teamProjects?__v=5",
+      "selector": "jsonpath:$.projects[*].name",
+      "keySelector": "jsonpath:$.projects[*].guid",
+      "authKey": "tfs:teamfoundation"
+    },
+    {
+      "target": "buildDefinitionId",
+      "endpoint": "/$(project)/_apis/build/Definitions?queryOrder=3",
+      "selector": "jsonpath:$.value[*].name",
+      "keySelector": "jsonpath:$.value[*].id",
+      "authKey": "tfs:teamfoundation"
+    },
+    {
+      "target": "buildNumber",
+      "endpoint": "/$(project)/_apis/build/builds?definitions=$(buildDefinitionId)",
+      "selector": "jsonpath:$.value[*].buildNumber",
+      "keySelector": "jsonpath:$.value[*].buildNumber",
+      "authKey": "tfs:teamfoundation"
+    }
+  ],
+  "execution": {
+    "Node": {
+      "target": "index.js",
+      "argumentFormat": ""
+    }
+  }
 }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,58 +1,58 @@
 {
-    "manifestVersion": 1,
-    "id": "fetch-build-artifact",
-    "name": "Fetch Build Artifacts",
-    "version": "0.0.1",
-    "publisher": "bool",
-    "targets": [
-        {
-            "id": "Microsoft.VisualStudio.Services.Cloud"
-        },
-        {
-            "id": "Microsoft.TeamFoundation.Server",
-            "version": "[15.0,)"
-        }
-    ],
-    "description": "Fetch build artifacts from server or file share, from any project and build definition, allowing the current build definition to make use of its contents.",
-    "categories": [
-        "Build and release"
-    ],
-    "tags": [
-        "Artifact", "Utility task", "Build", "Continuous Integration"
-    ],
-    "icons": {
-        "default": "icon-128.png",
-        "large": "icon-512.png"
+  "manifestVersion": 1,
+  "id": "fetch-build-artifact",
+  "name": "Fetch Build Artifacts",
+  "version": "0.0.1",
+  "publisher": "bool",
+  "targets": [
+    {
+      "id": "Microsoft.VisualStudio.Services.Cloud"
     },
-    "content": {
-        "details": {
-            "path": "overview.md"
-        }
+    {
+      "id": "Microsoft.TeamFoundation.Server",
+      "version": "[15.0,)"
+    }
+  ],
+  "description": "Fetch build artifacts from server or file share, from any project and build definition, allowing the current build definition to make use of its contents.",
+  "categories": [
+    "Build and release"
+  ],
+  "tags": [
+    "Artifact", "Utility task", "Build", "Continuous Integration"
+  ],
+  "icons": {
+    "default": "icon-128.png",
+    "large": "icon-512.png"
+  },
+  "content": {
+    "details": {
+      "path": "overview.md"
+    }
+  },
+  "links": {
+    "support": {
+      "uri": "https://github.com/BoolBySigma/FetchBuildArtifact/issues"
+    }
+  },
+  "files": [
+    {
+      "path": "fetch-build-artifact-task"
     },
-    "links": {
-        "support": {
-            "uri": "https://github.com/BoolBySigma/FetchBuildArtifact/issues"
-        }
-    },
-    "files": [
-        {
-            "path": "fetch-build-artifact-task"
-        },
-        {
-            "path": "images",
-            "addressable": true
-        }
-    ],
-    "contributions": [
-        {
-            "id": "fetch-build-artifact-task",
-            "type": "ms.vss-distributed-task.task",
-            "targets": [
-                "ms.vss-distributed-task.tasks"
-            ],
-            "properties": {
-                "name": "fetch-build-artifact-task"
-            }
-        }
-    ]
+    {
+      "path": "images",
+      "addressable": true
+    }
+  ],
+  "contributions": [
+    {
+      "id": "fetch-build-artifact-task",
+      "type": "ms.vss-distributed-task.task",
+      "targets": [
+        "ms.vss-distributed-task.tasks"
+      ],
+      "properties": {
+        "name": "fetch-build-artifact-task"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Adding fields that allow the ability to pick a specific build from a build definition and specify tags to search with.

If an exact build is set, the tags will be ignored.

This is to resolve #7 